### PR TITLE
Remove hardcoded Discord bot token in examples and add noqa comment f…

### DIFF
--- a/examples/discord/basic/bot.py
+++ b/examples/discord/basic/bot.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from ipcx_typed import Server
 
-TOKEN = "YOUR_DISCORD_BOT_TOKEN"
+TOKEN = ""
 
 
 class GuildParam(BaseModel):

--- a/examples/discord/reversed/bot.py
+++ b/examples/discord/reversed/bot.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from ipcx_typed import Client
 
-TOKEN = "YOUR_DISCORD_BOT_TOKEN"
+TOKEN = ""
 
 
 class UserSessionParam(BaseModel):

--- a/examples/simple_examples/calculator_server.py
+++ b/examples/simple_examples/calculator_server.py
@@ -75,7 +75,7 @@ async def main():
 
     try:
         # Keep server running
-        while True:
+        while True:  # noqa: ASYNC110
             await asyncio.sleep(1)
     except KeyboardInterrupt:
         logger.info("Shutting down server...")

--- a/examples/simple_examples/echo_server.py
+++ b/examples/simple_examples/echo_server.py
@@ -35,7 +35,7 @@ async def main():
 
     try:
         # Keep server running
-        while True:
+        while True:  # noqa: ASYNC110
             await asyncio.sleep(1)
     except KeyboardInterrupt:
         logger.info("Shutting down server...")


### PR DESCRIPTION
This pull request includes updates to improve code quality and security in example files. The most important changes involve replacing placeholder tokens with empty strings for better security and adding comments to suppress specific linting warnings for clarity.

### Security improvements:
* [`examples/discord/basic/bot.py`](diffhunk://#diff-7aebea39e7389f4f8279de60f164749d5b9c1374a3034075641c96f16ae29c87L7-R7): Replaced the placeholder `TOKEN` value `"YOUR_DISCORD_BOT_TOKEN"` with an empty string to prevent accidental token exposure.
* [`examples/discord/reversed/bot.py`](diffhunk://#diff-7b6e2b27b2fc3623286bcb0eba3f550e148b3e35318a8364460b2c1ee313b198L7-R7): Replaced the placeholder `TOKEN` value `"YOUR_DISCORD_BOT_TOKEN"` with an empty string to prevent accidental token exposure.

### Code quality improvements:
* [`examples/simple_examples/calculator_server.py`](diffhunk://#diff-001e5bbb195ee7857b8b28f82380b8ec7d549d6c75a1c120abdb094ea5b965daL78-R78): Added a `# noqa: ASYNC110` comment to suppress the linting warning about the `while True` loop in the `stats` function.
* [`examples/simple_examples/echo_server.py`](diffhunk://#diff-6ac54aba48e593e8cfa81f27d633b2c165719bb95b638a682527605c12caa97aL38-R38): Added a `# noqa: ASYNC110` comment to suppress the linting warning about the `while True` loop in the `echo` function.