### PR TITLE
Fix/tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,12 @@ repos:
       - id: ruff-format
         name: Ruff Formatter
         args: ["--config", "pyproject.toml"]
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: poetry run pytest
+        language: system
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
This pull request refactors the `ipcx_typed` client to introduce a unified `Response` model for handling server responses, replacing the previous approach of directly returning response data or raising exceptions. It also updates the test suite to validate the new response structure and ensures consistent error handling.

### Client Refactoring:
* Updated the `request` method in `ipcx_typed/client.py` to return a `Response[T]` object instead of the raw data or raising exceptions. This includes introducing `Response.create_success` and `Response.create_error` methods for success and error handling. [[1]](diffhunk://#diff-77fea4d0550e23b368870d73492f4d05f49e6234011d33d9326631909f58a42bL82-R82) [[2]](diffhunk://#diff-77fea4d0550e23b368870d73492f4d05f49e6234011d33d9326631909f58a42bL143-R149) [[3]](diffhunk://#diff-77fea4d0550e23b368870d73492f4d05f49e6234011d33d9326631909f58a42bL158-R162)
* Imported the `Response` model from `ipcx_typed.models` to support the new response structure.

### Pre-commit Configuration:
* Added a new local pre-commit hook for running `pytest` to enforce test execution before commits.

### Test Suite Updates:
* Replaced direct assertions on response data with validations of the `Response` object. This includes checking `success`, `data`, and `error_message` fields across unit and integration tests. [[1]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L56-R70) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L100-R147) [[3]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL62-R73) [[4]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL81-R90) [[5]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL95-R145)
* Added new test cases to validate error handling, such as invalid endpoints, invalid request data, and authorization errors, ensuring proper `Response` object structure. [[1]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L100-R147) [[2]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL95-R145)
* Updated reconnection tests to validate the new response structure after server restarts. [[1]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL135-R158) [[2]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL144-R170) [[3]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL154-R183) [[4]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL163-R195)