### PR TITLE
Refactor endpoint registration in Server and route decorators

### DIFF
--- a/ipcx_typed/server.py
+++ b/ipcx_typed/server.py
@@ -33,11 +33,8 @@ def route(
 
     def decorator(func: Callable[[T], Awaitable[Any]]) -> Callable[[T], Awaitable[Any]]:
         endpoint = Endpoint(func, param_model, return_model)
-        if not name:
-            Server.ROUTES[func.__name__] = endpoint
-        else:
-            Server.ROUTES[name] = endpoint
-
+        fn_name = name or func.__name__
+        Server.ROUTES[fn_name] = endpoint
         return func
 
     return decorator
@@ -94,10 +91,8 @@ class Server:
 
         def decorator(func: Callable[[T], Awaitable[Any]]) -> Callable[[T], Awaitable[Any]]:
             endpoint = Endpoint(func, param_model, return_model)
-            if not name:
-                self.endpoints[func.__name__] = endpoint
-            else:
-                self.endpoints[name] = endpoint
+            fn_name = name or func.__name__
+            self.endpoints[fn_name] = endpoint
             return func
 
         return decorator


### PR DESCRIPTION
This pull request refactors the `route` method in the `ipcx_typed/server.py` file to simplify the logic for assigning endpoint names. The changes consolidate conditional logic into a single line, improving code readability and maintainability.

### Refactoring of `route` method:

* Updated the `route` method in `Server` to replace the conditional assignment of the `ROUTES` dictionary with a single line using the `name or func.__name__` expression. (`ipcx_typed/server.py`, [ipcx_typed/server.pyL36-R37](diffhunk://#diff-a5100191b536effe3d59861a8896538ce0d54f9113d715f2c7134072018c7e77L36-R37))
* Updated the `route` method in the instance-level implementation to similarly simplify the assignment of the `endpoints` dictionary using the `name or func.__name__` expression. (`ipcx_typed/server.py`, [ipcx_typed/server.pyL97-R95](diffhunk://#diff-a5100191b536effe3d59861a8896538ce0d54f9113d715f2c7134072018c7e77L97-R95))…lify name handling

- Consolidated the logic for assigning endpoint names by using a single line to determine the function name, improving code readability and maintainability.